### PR TITLE
[MM-14189] Update references to "mattermost-plugin-sample" to be "mattermost-plugin-starter-template"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sample Plugin ![CircleCI branch](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-sample/master.svg)
+# Plugin Starter Template ![CircleCI branch](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-starter-template/master.svg)
 
 This plugin serves as a starting point for writing a Mattermost plugin. Feel free to base your own plugin off this repository.
 
@@ -9,7 +9,7 @@ Use GitHub's template feature to make a copy of this repository by clicking the 
 
 Alternatively shallow clone the repository to a directory outside of `$GOPATH` matching your plugin name:
 ```
-git clone --depth 1 https://github.com/mattermost/mattermost-plugin-sample com.example.my-plugin
+git clone --depth 1 https://github.com/mattermost/mattermost-plugin-starter-template com.example.my-plugin
 ```
 
 Note that this project uses [Go modules](https://github.com/golang/go/wiki/Modules). Be sure to locate the project outside of `$GOPATH`, or allow the use of Go modules within your `$GOPATH` with an `export GO111MODULE=on`.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mattermost/mattermost-plugin-sample
+module github.com/mattermost/mattermost-plugin-starter-template
 
 go 1.12
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
-    "id": "com.mattermost.sample-plugin",
-    "name": "Sample Plugin",
+    "id": "com.mattermost.plugin-starter-template",
+    "name": "Plugin Starter Template",
     "description": "This plugin serves as a starting point for writing a Mattermost plugin.",
     "version": "0.1.0",
     "min_server_version": "5.12.0",

--- a/public/hello.html
+++ b/public/hello.html
@@ -1,1 +1,1 @@
-Hello from the static files public folder for the com.mattermost.sample-plugin plugin!
+Hello from the static files public folder for the com.mattermost.plugin-starter-template plugin!

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -4,6 +4,6 @@ var manifest = struct {
 	ID      string
 	Version string
 }{
-	ID:      "com.mattermost.sample-plugin",
+	ID:      "com.mattermost.plugin-starter-template",
 	Version: "0.1.0",
 }

--- a/webapp/src/manifest.js
+++ b/webapp/src/manifest.js
@@ -1,2 +1,2 @@
-export const id = 'com.mattermost.sample-plugin';
+export const id = 'com.mattermost.plugin-starter-template';
 export const version = '0.1.0';


### PR DESCRIPTION
The name of this repo has been decided to change from `mattermost-plugin-sample` to `mattermost-plugin-starter-template`. As a result, any references to the original name in documentation needs to be updated, including this repo.

All the changes are pretty straightforward. One thing I am hesitant to change here is the id of the plugin itself. I'm not sure what implications the change would have. This may be irrelevant, but there was recently [discussion](https://community.mattermost.com/core/pl/kjjc9btof7be7q96x6o6acpj8o) about renaming the id of a plugin, and it seemed as if that was taboo.

I have included the id change here from `com.mattermost.sample-plugin` to `com.mattermost.plugin-starter-template`. Do you have an opinion on this @hanzei?

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-14189