### PR TITLE
[MM-11829] Add example of custom admin console for plugin

### DIFF
--- a/webapp/src/components/settings.jsx
+++ b/webapp/src/components/settings.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default class Settings extends React.Component {
+    render() {
+        return (<div>{'Hello, world!'}</div>);
+    }
+}

--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -1,9 +1,32 @@
 import {id as pluginId} from './manifest';
 
+import Settings from './components/settings.jsx';
+
+// eslint-disable-next-line no-unused-vars
+function addToAdminConsole(registry) {
+    registry.registerAdminConsolePlugin((adminDefinition) => {
+        // the settings will appear on the authentication section
+        adminDefinition.authentication.starter = {
+            url: 'plugins/starter',
+            icon: 'fa-rocket',
+            title: 'com.mattermost.starter-plugin.title',
+            title_default: 'Starter',
+            isHidden: () => false,
+            schema: {
+                id: 'StarterPlugin',
+                component: Settings,
+            },
+        };
+        return adminDefinition;
+    });
+}
+
 export default class Plugin {
     // eslint-disable-next-line no-unused-vars
     initialize(registry, store) {
         // @see https://developers.mattermost.com/extend/plugins/webapp/reference/
+
+        // addToAdminConsole(registry);
     }
 }
 


### PR DESCRIPTION
https://mattermost.atlassian.net/browse/MM-11829

Adds a function (commented by default) to add the plugin with a custom "Hello, world" component to the Authentication section.

Related to https://github.com/mattermost/mattermost-server/issues/10320

Depends on https://github.com/mattermost/mattermost-webapp/pull/2794

@jespino