### PR TITLE
GH-10166 - Call to CheckRequiredConfig when OnActivate is hit

### DIFF
--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -12,12 +12,20 @@ import (
 
 const pluginIDGoFileTemplate = `package main
 
+import (
+	"strings"
+
+	"github.com/mattermost/mattermost-server/model"
+)
+
 var manifest = struct {
-	ID      string
-	Version string
+	ID             string
+	Version        string
+	RequiredConfig *model.Config
 }{
-	ID:      "%s",
-	Version: "%s",
+	ID:             "%s",
+	Version:        "%s",
+	RequiredConfig: model.ConfigFromJson(strings.NewReader(` + "`%s`" + `)),
 }
 `
 
@@ -101,7 +109,7 @@ func applyManifest(manifest *model.Manifest) error {
 	if manifest.HasServer() {
 		if err := ioutil.WriteFile(
 			"server/manifest.go",
-			[]byte(fmt.Sprintf(pluginIDGoFileTemplate, manifest.Id, manifest.Version)),
+			[]byte(fmt.Sprintf(pluginIDGoFileTemplate, manifest.Id, manifest.Version, model.ConfigToJsonWithoutEmptyFields(manifest.RequiredConfig))),
 			0644,
 		); err != nil {
 			return errors.Wrap(err, "failed to write server/manifest.go")

--- a/plugin.json
+++ b/plugin.json
@@ -18,5 +18,10 @@
         "header": "",
         "footer": "",
         "settings": []
+    },
+    "requires_config": {
+        "ServiceSettings": {
+            "EnablePostUsernameOverride": true
+        }
     }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -19,7 +19,7 @@
         "footer": "",
         "settings": []
     },
-    "requires_config": {
+    "required_config": {
         "ServiceSettings": {
             "EnablePostUsernameOverride": true
         }

--- a/server/activate.go
+++ b/server/activate.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// OnActivate is executed when the plugin is activated
+func (p *Plugin) OnActivate() error {
+	p.API.LogDebug("Activating plugin")
+
+	isCompatible, requirements, err := p.API.CheckRequiredConfig()
+	if err != nil {
+		return errors.Wrap(err, "Error checking plugin compatibility")
+	}
+
+	if !isCompatible {
+		errMsg := fmt.Sprintf("Not activating plugin because it is not compatible with the system. Requirements: %s", requirements)
+		p.API.LogError(errMsg)
+		return errors.New(errMsg)
+	}
+
+	return nil
+}

--- a/server/activate.go
+++ b/server/activate.go
@@ -1,22 +1,23 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
+	"github.com/mattermost/mattermost-server/model"
 )
 
 // OnActivate is executed when the plugin is activated
 func (p *Plugin) OnActivate() error {
 	p.API.LogDebug("Activating plugin")
 
-	isCompatible, requirements, err := p.API.CheckRequiredConfig()
+	isCompatible, err := p.Helpers.CheckRequiredConfig(manifest.RequiredConfig, p.API.GetConfig())
 	if err != nil {
-		return errors.Wrap(err, "Error checking plugin compatibility")
+		return err
 	}
 
 	if !isCompatible {
-		errMsg := fmt.Sprintf("Not activating plugin because it is not compatible with the system. Requirements: %s", requirements)
+		errMsg := fmt.Sprintf("Not activating plugin because it is not compatible with the system. Requirements: %s", model.ConfigToJsonWithoutEmptyFields(manifest.RequiredConfig))
 		p.API.LogError(errMsg)
 		return errors.New(errMsg)
 	}

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -1,9 +1,17 @@
 package main
 
+import (
+	"strings"
+
+	"github.com/mattermost/mattermost-server/model"
+)
+
 var manifest = struct {
-	ID      string
-	Version string
+	ID             string
+	Version        string
+	RequiredConfig *model.Config
 }{
-	ID:      "com.mattermost.plugin-starter-template",
-	Version: "0.1.0",
+	ID:             "com.mattermost.plugin-starter-template",
+	Version:        "0.1.0",
+	RequiredConfig: model.ConfigFromJson(strings.NewReader(`{"ServiceSettings":{"EnablePostUsernameOverride":true}}`)),
 }


### PR DESCRIPTION
#### Summary
Show how to use `CheckRequiredConfig` at `OnActivate`.

Needs the changes on the server merged before this can be merged, as the new API method would not be available otherwise.

#### Ticket Link
[#10166 - Plugin framework: Show that a plugin requires a certain Mattermost config setting](https://github.com/mattermost/mattermost-server/issues/10166)

#### Related PRs
Server change: [Plugin framework: Show that a plugin requires a certain Mattermost config setting ](https://github.com/mattermost/mattermost-server/pull/11832)