### PR TITLE
Add a link to the project status page on CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Plugin Starter Template ![CircleCI branch](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-starter-template/master.svg)
+# Plugin Starter Template [![](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-starter-template/master.svg)](https://circleci.com/gh/mattermost/mattermost-plugin-starter-template)
 
 This plugin serves as a starting point for writing a Mattermost plugin. Feel free to base your own plugin off this repository.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Plugin Starter Template [![](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-starter-template/master.svg)](https://circleci.com/gh/mattermost/mattermost-plugin-starter-template)
+# Plugin Starter Template [![CircleCI branch](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-starter-template/master.svg)](https://circleci.com/gh/mattermost/mattermost-plugin-starter-template)
 
 This plugin serves as a starting point for writing a Mattermost plugin. Feel free to base your own plugin off this repository.
 


### PR DESCRIPTION
- ~~Avoids to use shields.io's badge~~
- Adds a useful link to the CircleCI pipeline results

cf. some usecase in a certain project: wbernest/mattermost-plugin-rssfeed#18