### PR TITLE
Fix invalid import in manifest.go

### DIFF
--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -17,7 +17,7 @@ package main
 import (
 	"strings"
 
-	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/v5/model"
 )
 
 var manifest *model.Manifest

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -5,7 +5,7 @@ package main
 import (
 	"strings"
 
-	"github.com/mattermost/mattermost-server/model"
+	"github.com/mattermost/mattermost-server/v5/model"
 )
 
 var manifest *model.Manifest


### PR DESCRIPTION
#### Summary
Fix invalid in import in `server/manifest.go`. This fixes the broken `master`. 

#### Ticket Link
`master` broken due to https://github.com/mattermost/mattermost-plugin-starter-template/pull/76
