### PR TITLE
Allow make deploy using token

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,18 @@ This will produce a single plugin file (with support for multiple architectures)
 dist/com.example.my-plugin.tar.gz
 ```
 
-There is a build target to automate deploying and enabling the plugin to your server, but it requires configuration of a [personal access token](https://docs.mattermost.com/developer/personal-access-tokens.html):
-```
-export MM_SERVICESETTINGS_SITEURL=http://localhost:8065
-export MM_ADMIN_TOKEN=j44acwd8obn78cdcx7koid4jkr
-make deploy
-```
-
-or login credentials:
+There is a build target to automate deploying and enabling the plugin to your server, but it requires login credentials:
 ```
 export MM_SERVICESETTINGS_SITEURL=http://localhost:8065
 export MM_ADMIN_USERNAME=admin
 export MM_ADMIN_PASSWORD=password
+make deploy
+```
+
+or configuration of a [personal access token](https://docs.mattermost.com/developer/personal-access-tokens.html):
+```
+export MM_SERVICESETTINGS_SITEURL=http://localhost:8065
+export MM_ADMIN_TOKEN=j44acwd8obn78cdcx7koid4jkr
 make deploy
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,14 @@ This will produce a single plugin file (with support for multiple architectures)
 dist/com.example.my-plugin.tar.gz
 ```
 
-There is a build target to automate deploying and enabling the plugin to your server, but it requires configuration and [http](https://httpie.org/) to be installed:
+There is a build target to automate deploying and enabling the plugin to your server, but it requires configuration of a [personal access token](https://docs.mattermost.com/developer/personal-access-tokens.html):
+```
+export MM_SERVICESETTINGS_SITEURL=http://localhost:8065
+export MM_ADMIN_TOKEN=j44acwd8obn78cdcx7koid4jkr
+make deploy
+```
+
+or login credentials:
 ```
 export MM_SERVICESETTINGS_SITEURL=http://localhost:8065
 export MM_ADMIN_USERNAME=admin

--- a/build/deploy/main.go
+++ b/build/deploy/main.go
@@ -52,7 +52,7 @@ func deploy() error {
 			log.Printf("Authenticating as %s against %s.", adminUsername, siteURL)
 			_, resp := client.Login(adminUsername, adminPassword)
 			if resp.Error != nil {
-				return fmt.Errorf("Failed to login as %s: %s", adminUsername, resp.Error.Error())
+				return errors.Wrapf(resp.Error, "failed to login as %s: %s", adminUsername, resp.Error.Error())
 			}
 
 			return uploadPlugin(client, pluginID, bundlePath)
@@ -63,7 +63,7 @@ func deploy() error {
 	if os.IsNotExist(err) {
 		return errors.New("no supported deployment method available, please install plugin manually")
 	} else if err != nil {
-		return errors.Errorf("Failed to stat %s", copyTargetDirectory)
+		return errors.Wrapf(err, "failed to stat %s", copyTargetDirectory)
 	}
 
 	log.Printf("Installing plugin to mattermost-server found in %s.", copyTargetDirectory)

--- a/build/deploy/main.go
+++ b/build/deploy/main.go
@@ -48,7 +48,7 @@ func deploy() error {
 
 			return uploadPlugin(client, pluginID, bundlePath)
 		}
-		
+
 		if adminUsername != "" && adminPassword != "" {
 			client := model.NewAPIv4Client(siteURL)
 			log.Printf("Authenticating as %s against %s.", adminUsername, siteURL)

--- a/build/deploy/main.go
+++ b/build/deploy/main.go
@@ -34,11 +34,29 @@ func deploy() error {
 	bundlePath := os.Args[2]
 
 	siteURL := os.Getenv("MM_SERVICESETTINGS_SITEURL")
+	adminToken := os.Getenv("MM_ADMIN_TOKEN")
 	adminUsername := os.Getenv("MM_ADMIN_USERNAME")
 	adminPassword := os.Getenv("MM_ADMIN_PASSWORD")
 	copyTargetDirectory, _ := filepath.Abs("../mattermost-server")
-	if siteURL != "" && adminUsername != "" && adminPassword != "" {
-		return uploadPlugin(pluginID, bundlePath, siteURL, adminUsername, adminPassword)
+
+	if siteURL != "" {
+		client := model.NewAPIv4Client(siteURL)
+
+		if adminToken != "" {
+			log.Printf("Authenticating using token against %s.", siteURL)
+			client.SetToken(adminToken)
+
+			return uploadPlugin(client, pluginID, bundlePath)
+		} else if adminUsername != "" && adminPassword != "" {
+			client := model.NewAPIv4Client(siteURL)
+			log.Printf("Authenticating as %s against %s.", adminUsername, siteURL)
+			_, resp := client.Login(adminUsername, adminPassword)
+			if resp.Error != nil {
+				return fmt.Errorf("Failed to login as %s: %s", adminUsername, resp.Error.Error())
+			}
+
+			return uploadPlugin(client, pluginID, bundlePath)
+		}
 	}
 
 	_, err := os.Stat(copyTargetDirectory)
@@ -55,14 +73,7 @@ func deploy() error {
 
 // uploadPlugin attempts to upload and enable a plugin via the Client4 API.
 // It will fail if plugin uploads are disabled.
-func uploadPlugin(pluginID, bundlePath, siteURL, adminUsername, adminPassword string) error {
-	client := model.NewAPIv4Client(siteURL)
-	log.Printf("Authenticating as %s against %s.", adminUsername, siteURL)
-	_, resp := client.Login(adminUsername, adminPassword)
-	if resp.Error != nil {
-		return fmt.Errorf("Failed to login as %s: %s", adminUsername, resp.Error.Error())
-	}
-
+func uploadPlugin(client *model.Client4, pluginID, bundlePath string) error {
 	pluginBundle, err := os.Open(bundlePath)
 	if err != nil {
 		return errors.Wrapf(err, "failed to open %s", bundlePath)
@@ -70,7 +81,7 @@ func uploadPlugin(pluginID, bundlePath, siteURL, adminUsername, adminPassword st
 	defer pluginBundle.Close()
 
 	log.Print("Uploading plugin via API.")
-	_, resp = client.UploadPluginForced(pluginBundle)
+	_, resp := client.UploadPluginForced(pluginBundle)
 	if resp.Error != nil {
 		return fmt.Errorf("Failed to upload plugin bundle: %s", resp.Error.Error())
 	}

--- a/build/deploy/main.go
+++ b/build/deploy/main.go
@@ -47,7 +47,9 @@ func deploy() error {
 			client.SetToken(adminToken)
 
 			return uploadPlugin(client, pluginID, bundlePath)
-		} else if adminUsername != "" && adminPassword != "" {
+		}
+		
+		if adminUsername != "" && adminPassword != "" {
 			client := model.NewAPIv4Client(siteURL)
 			log.Printf("Authenticating as %s against %s.", adminUsername, siteURL)
 			_, resp := client.Login(adminUsername, adminPassword)


### PR DESCRIPTION
#### Summary
Introduce support for `MM_ADMIN_TOKEN` as an alternative to defining `MM_ADMIN_USERNAME` and `MM_ADMIN_PASSWORD`.