### PR TITLE
Remove `node_modules` from root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 dist
-node_modules
 
 # Mac
 .DS_Store


### PR DESCRIPTION
#### Summary

PR https://github.com/mattermost/mattermost-plugin-starter-template/pull/80 incorrectly added `node_modules` to the root `.gitignore`. 
