### PR TITLE
Add `corejs: 3`, and pull out babel config from webpack config

### DIFF
--- a/webapp/babel.config.js
+++ b/webapp/babel.config.js
@@ -1,0 +1,44 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+const config = {
+    presets: [
+        ['@babel/preset-env', {
+            targets: {
+                chrome: 66,
+                firefox: 60,
+                edge: 42,
+                safari: 12,
+            },
+            modules: false,
+            corejs: 3,
+            debug: false,
+            useBuiltIns: 'usage',
+            shippedProposals: true,
+        }],
+        ['@babel/preset-react', {
+            useBuiltIns: true,
+        }],
+        ['@babel/typescript', {
+            allExtensions: true,
+            isTSX: true,
+        }],
+    ],
+    plugins: [
+        '@babel/plugin-proposal-class-properties',
+        '@babel/plugin-syntax-dynamic-import',
+        '@babel/proposal-object-rest-spread',
+        'babel-plugin-typescript-to-proptypes',
+    ],
+};
+
+// Jest needs module transformation
+config.env = {
+    test: {
+        presets: config.presets,
+        plugins: config.plugins,
+    },
+};
+config.env.test.presets[0][1].modules = 'auto';
+
+module.exports = config;

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = {
                     options: {
                         cacheDirectory: true,
 
-                        // Babel configuration is in .babelrc because jest requires it to be there.
+                        // Babel configuration is in babel.config.js because jest requires it to be there.
                     },
                 },
             },

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -19,33 +19,9 @@ module.exports = {
                 use: {
                     loader: 'babel-loader',
                     options: {
-                        plugins: [
-                            '@babel/plugin-proposal-class-properties',
-                            '@babel/plugin-syntax-dynamic-import',
-                            '@babel/proposal-object-rest-spread',
-                            'babel-plugin-typescript-to-proptypes',
-                        ],
-                        presets: [
-                            ['@babel/preset-env', {
-                                targets: {
-                                    chrome: 66,
-                                    firefox: 60,
-                                    edge: 42,
-                                    safari: 12,
-                                },
-                                modules: false,
-                                debug: false,
-                                useBuiltIns: 'usage',
-                                shippedProposals: true,
-                            }],
-                            ['@babel/preset-react', {
-                                useBuiltIns: true,
-                            }],
-                            ['@babel/typescript', {
-                                allExtensions: true,
-                                isTSX: true,
-                            }],
-                        ],
+                        cacheDirectory: true,
+
+                        // Babel configuration is in .babelrc because jest requires it to be there.
                     },
                 },
             },


### PR DESCRIPTION
#### Summary

Some babel transformations (such as rest/spread operators) are currently not available because `corejs` is not properly used in the babel config. This PR fixes that by including it.

This PR also pulls out the babel config, so Jest may properly have access to it.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-22298