### PR TITLE
Cleanup deploy error message

### DIFF
--- a/build/deploy/main.go
+++ b/build/deploy/main.go
@@ -54,7 +54,7 @@ func deploy() error {
 			log.Printf("Authenticating as %s against %s.", adminUsername, siteURL)
 			_, resp := client.Login(adminUsername, adminPassword)
 			if resp.Error != nil {
-				return errors.Wrapf(resp.Error, "failed to login as %s: %s", adminUsername, resp.Error.Error())
+				return errors.Wrapf(resp.Error, "failed to login as %s", adminUsername)
 			}
 
 			return uploadPlugin(client, pluginID, bundlePath)


### PR DESCRIPTION
This removes a double print of the API response error message.

Old:

```
Failed to deploy: failed to login as admin: : Enter a valid email or username and/or password., : : Enter a valid email or username and/or password.,
```

New:

```
Failed to deploy: failed to login as admin: : Enter a valid email or username and/or password.,
```

Better, but still seems to have a strange error format returned from the server. I didn't have time to look into if this was fixed recently as my server is intentionally a bit out of date, but I wanted to note it.