### PR TITLE
auto npm install on sha256(package.json) changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ apply:
 
 ## Runs golangci-lint and eslint.
 .PHONY: check-style
-check-style: webapp/.npminstall golangci-lint
+check-style: npminstall golangci-lint
 	@echo Checking for style guide compliance
 
 ifneq ($(HAS_WEBAPP),)
@@ -61,22 +61,22 @@ ifneq ($(HAS_SERVER),)
 endif
 
 ## Ensures NPM dependencies are installed without having to run this all the time.
-webapp/.npminstall:
+.PHONY: npminstall
+npminstall:
 ifneq ($(HAS_WEBAPP),)
-	cd webapp && $(NPM) install
-	touch $@
+	./build/bin/webapp check ./webapp || (pushd webapp && $(NPM) install && popd && ./build/bin/webapp update ./webapp)
 endif
 
 ## Builds the webapp, if it exists.
 .PHONY: webapp
-webapp: webapp/.npminstall
+webapp: npminstall
 ifneq ($(HAS_WEBAPP),)
 	cd webapp && $(NPM) run build;
 endif
 
 ## Builds the webapp in debug mode, if it exists.
 .PHONY: webapp-debug
-webapp-debug: webapp/.npminstall
+webapp-debug: npminstall
 ifneq ($(HAS_WEBAPP),)
 	cd webapp && \
 	$(NPM) run debug;
@@ -125,7 +125,7 @@ debug-dist: apply server webapp-debug bundle
 
 ## Runs any lints and unit tests defined for the server and webapp, if they exist.
 .PHONY: test
-test: webapp/.npminstall
+test: npminstall
 ifneq ($(HAS_SERVER),)
 	$(GO) test -v $(GO_TEST_FLAGS) ./server/...
 endif
@@ -135,7 +135,7 @@ endif
 
 ## Creates a coverage report for the server code.
 .PHONY: coverage
-coverage: webapp/.npminstall
+coverage: npminstall
 ifneq ($(HAS_SERVER),)
 	$(GO) test $(GO_TEST_FLAGS) -coverprofile=server/coverage.txt ./server/...
 	$(GO) tool cover -html=server/coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ endif
 .PHONY: npminstall
 npminstall:
 ifneq ($(HAS_WEBAPP),)
-	./build/bin/webapp check ./webapp || (pushd webapp && $(NPM) install && popd && ./build/bin/webapp update ./webapp)
+	./build/bin/webapp check ./webapp || (cd webapp && $(NPM) install && cd - && ./build/bin/webapp update ./webapp)
 endif
 
 ## Builds the webapp, if it exists.

--- a/build/setup.mk
+++ b/build/setup.mk
@@ -10,6 +10,9 @@ $(shell cd build/manifest && $(GO) build -o ../bin/manifest)
 # Ensure that the deployment tools are compiled. Go's caching makes this quick.
 $(shell cd build/deploy && $(GO) build -o ../bin/deploy)
 
+# Ensure that the webapp tool is compiled. Go's caching makes this quick.
+$(shell cd build/webapp && $(GO) build -o ../bin/webapp)
+
 # Extract the plugin id from the manifest.
 PLUGIN_ID ?= $(shell build/bin/manifest id)
 ifeq ($(PLUGIN_ID),)

--- a/build/webapp/main.go
+++ b/build/webapp/main.go
@@ -1,0 +1,149 @@
+// main exits with a non-0 status code if its necessary to run npm install
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+)
+
+func main() {
+	if len(os.Args) == 1 {
+		help()
+		return
+	}
+
+	if len(os.Args) != 3 {
+		fmt.Println("Unexpected arguments.")
+		help()
+		os.Exit(1)
+	}
+
+	cmd := os.Args[1]
+	webappPath := os.Args[2]
+	if cmd == "check" {
+		matches, err := check(webappPath)
+		if err != nil {
+			fmt.Printf("Failed to check if .npminstall contains package.json hash: %s\n", err.Error())
+			os.Exit(1)
+		}
+		if !matches {
+			os.Exit(2)
+		}
+
+	} else if cmd == "update" {
+		err := update(webappPath)
+		if err != nil {
+			fmt.Printf("Failed to update .npminstall with hash of package.json: %s\n", err.Error())
+			os.Exit(1)
+		}
+
+	} else {
+		fmt.Printf("Unexpected command %s\n\n", cmd)
+		help()
+
+		os.Exit(1)
+	}
+}
+
+// help outputs instructions on how to use the command
+func help() {
+	fmt.Println("Usage:")
+	fmt.Println("    webapp check <webapp path>")
+	fmt.Println("    webapp update <webapp path>")
+	fmt.Println()
+}
+
+// check checks if .npminstall contains the sha256 of package.json.
+func check(webappPath string) (bool, error) {
+	packageJsonPath := filepath.Join(webappPath, "package.json")
+	packageJsonHash, err := hashFile(packageJsonPath)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to hash")
+	}
+
+	npmInstallPath := filepath.Join(webappPath, ".npminstall")
+	npmInstallHash, err := readHashFromFile(npmInstallPath)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to read hash")
+	}
+
+	if len(npmInstallHash) == 0 {
+		fmt.Printf("no previously recorded hash of %s (%x) in %s\n", packageJsonPath, packageJsonHash, npmInstallPath)
+		return false, nil
+	}
+
+	if bytes.Equal(packageJsonHash, npmInstallHash) {
+		return true, nil
+	}
+
+	fmt.Printf("hash of %s (%x) different from value recorded in %s (%x)\n", packageJsonPath, packageJsonHash, npmInstallPath, npmInstallHash)
+
+	return false, nil
+}
+
+// update updates .npminstall with the sha256 of package.json.
+func update(webappPath string) error {
+	packageJsonPath := filepath.Join(webappPath, "package.json")
+	packageJsonHash, err := hashFile(packageJsonPath)
+	if err != nil {
+		return errors.Wrap(err, "failed to hash")
+	}
+
+	npmInstallPath := filepath.Join(webappPath, ".npminstall")
+	err = ioutil.WriteFile(npmInstallPath, []byte(hex.EncodeToString(packageJsonHash)), 0644)
+	if err != nil {
+		return errors.Wrapf(err, "failed to write hash to %s", npmInstallPath)
+	}
+
+	return nil
+}
+
+// hashFile computes the sha256 hash of the given file
+func hashFile(filePath string) ([]byte, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open %s", filePath)
+	}
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, f); err != nil {
+		return nil, errors.Wrapf(err, "failed to hash %s", filePath)
+	}
+
+	return hash.Sum(nil), nil
+}
+
+// readHashFromFile recovers a hash previously written to the given file
+func readHashFromFile(filePath string) ([]byte, error) {
+	f, err := os.Open(filePath)
+	if os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
+		return nil, errors.Wrapf(err, "failed to open %s", filePath)
+	}
+
+	hashString, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read %s", filePath)
+	}
+
+	if len(hashString) == 0 {
+		return nil, nil
+	}
+
+	hash, err := hex.DecodeString(string(hashString))
+	if err != nil {
+		fmt.Printf("ignoring unexpected hash string in %s: %s\n", filePath, string(hashString))
+		return nil, nil
+	}
+
+	return hash, nil
+}

--- a/build/webapp/main.go
+++ b/build/webapp/main.go
@@ -28,7 +28,8 @@ func main() {
 
 	cmd := os.Args[1]
 	webappPath := os.Args[2]
-	if cmd == "check" {
+	switch cmd {
+	case "check":
 		matches, err := check(webappPath)
 		if err != nil {
 			fmt.Printf("Failed to check if .npminstall contains package.json hash: %s\n", err.Error())
@@ -38,14 +39,14 @@ func main() {
 			os.Exit(2)
 		}
 
-	} else if cmd == "update" {
+	case "update":
 		err := update(webappPath)
 		if err != nil {
 			fmt.Printf("Failed to update .npminstall with hash of package.json: %s\n", err.Error())
 			os.Exit(1)
 		}
 
-	} else {
+	default:
 		fmt.Printf("Unexpected command %s\n\n", cmd)
 		help()
 
@@ -63,8 +64,8 @@ func help() {
 
 // check checks if .npminstall contains the sha256 of package.json.
 func check(webappPath string) (bool, error) {
-	packageJsonPath := filepath.Join(webappPath, "package.json")
-	packageJsonHash, err := hashFile(packageJsonPath)
+	packageJSONPath := filepath.Join(webappPath, "package.json")
+	packageJSONHash, err := hashFile(packageJSONPath)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to hash")
 	}
@@ -76,29 +77,29 @@ func check(webappPath string) (bool, error) {
 	}
 
 	if len(npmInstallHash) == 0 {
-		fmt.Printf("no previously recorded hash of %s (%x) in %s\n", packageJsonPath, packageJsonHash, npmInstallPath)
+		fmt.Printf("no previously recorded hash of %s (%x) in %s\n", packageJSONPath, packageJSONHash, npmInstallPath)
 		return false, nil
 	}
 
-	if bytes.Equal(packageJsonHash, npmInstallHash) {
+	if bytes.Equal(packageJSONHash, npmInstallHash) {
 		return true, nil
 	}
 
-	fmt.Printf("hash of %s (%x) different from value recorded in %s (%x)\n", packageJsonPath, packageJsonHash, npmInstallPath, npmInstallHash)
+	fmt.Printf("hash of %s (%x) different from value recorded in %s (%x)\n", packageJSONPath, packageJSONHash, npmInstallPath, npmInstallHash)
 
 	return false, nil
 }
 
 // update updates .npminstall with the sha256 of package.json.
 func update(webappPath string) error {
-	packageJsonPath := filepath.Join(webappPath, "package.json")
-	packageJsonHash, err := hashFile(packageJsonPath)
+	packageJSONPath := filepath.Join(webappPath, "package.json")
+	packageJSONHash, err := hashFile(packageJSONPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to hash")
 	}
 
 	npmInstallPath := filepath.Join(webappPath, ".npminstall")
-	err = ioutil.WriteFile(npmInstallPath, []byte(hex.EncodeToString(packageJsonHash)), 0644)
+	err = ioutil.WriteFile(npmInstallPath, []byte(hex.EncodeToString(packageJSONHash)), 0644)
 	if err != nil {
 		return errors.Wrapf(err, "failed to write hash to %s", npmInstallPath)
 	}


### PR DESCRIPTION
#### Summary
Use the existing `.npminstall` file to track the hash of `package.json` from the last successful `npm install`. This will automatically install new dependencies when they change in addition to avoiding unnecessary rebuilds.

I was burned by this for the last time today.