### PR TITLE
MM-25822: Import react-router-dom from the webapp

### DIFF
--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -33,6 +33,7 @@ module.exports = {
         'react-redux': 'ReactRedux',
         'prop-types': 'PropTypes',
         'react-bootstrap': 'ReactBootstrap',
+        'react-router-dom': 'ReactRouterDom',
     },
     output: {
         path: path.join(__dirname, '/dist'),


### PR DESCRIPTION
#### Summary
This PR declares the `react-router-dom` package as an external dependency to make use of all the routing utils declared there.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25822

#### Related Pull Requests
https://github.com/mattermost/mattermost-webapp/pull/5665