### PR TITLE
Remove non-project-related items from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,1 @@
-dist
-
-# Mac
-.DS_Store
-
-# VSCode
-.vscode
+dist/


### PR DESCRIPTION
IDE-specific and OS-specific files should be in global gitignores. The project gitignore should be for files created by the project.