### PR TITLE
Drop interfacer and goconst from golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,7 +33,6 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - misspell
     - nakedret
     - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,9 +3,6 @@ run:
   modules-download-mode: readonly
 
 linters-settings:
-  goconst:
-    min-len: 2
-    min-occurrences: 2
   gofmt:
     simplify: true
   goimports:
@@ -24,7 +21,6 @@ linters:
     - bodyclose
     - deadcode
     - errcheck
-    - goconst
     - gocritic
     - gofmt
     - goimports
@@ -57,5 +53,4 @@ issues:
     - path: _test\.go
       linters:
         - bodyclose
-        - goconst
         - scopelint # https://github.com/kyoh86/scopelint/issues/4


### PR DESCRIPTION
#### Summary
Both linter haven't been proven useful and created more false positives then correct results.

#### Ticket Link
https://community.mattermost.com/core/pl/r5fdx8xmp3na8er87zkt5pyqpy

