### PR TITLE
Skip the `webapp/package.json` if it is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ endif
 endif
 
 ## Ensures NPM dependencies are installed without having to run this all the time.
-webapp/node_modules: webapp/package.json
+webapp/node_modules: $(wildcard webapp/package.json)
 ifneq ($(HAS_WEBAPP),)
 	cd webapp && $(NPM) install
 	touch $@


### PR DESCRIPTION
#### Summary

I've used the [wildcard function](https://www.gnu.org/software/make/manual/html_node/Wildcard-Function.html) to skip the `webapp/package.json` target dependency if it is missing.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-starter-template/issues/112.