### PR TITLE
Disable git file history test that relies on commits not being squashed in github PR merges.

### DIFF
--- a/build/sync/plan/git/file_history_test.go
+++ b/build/sync/plan/git/file_history_test.go
@@ -25,9 +25,4 @@ func TestFileHistory(t *testing.T) {
 	sums, err = gitutil.FileHistory("build/sync/plan/git/testdata/nosuch_testfile.txt", repo)
 	assert.Equal(gitutil.ErrNotFound, err)
 	assert.Nil(sums)
-
-	// Calling with a non-existent file that was in git history returns no error.
-	sums, err = gitutil.FileHistory("build/sync/plan/git/testdata/removedfile.txt", repo)
-	assert.Nil(err)
-	assert.Equal([]string{"213df5d04c108c99d3ec9ffe43a53f638f0ede0b"}, sums)
 }


### PR DESCRIPTION
This is to fix CI breakage ( https://app.circleci.com/pipelines/github/mattermost/mattermost-plugin-starter-template/428/workflows/508a6d30-001a-4087-b353-52dddc71683c/jobs/981 ) after landing https://github.com/mattermost/mattermost-plugin-starter-template/pull/128