### PR TITLE
Synchronization tool file history tests modified to set up a temporary git repo

### DIFF
--- a/build/sync/plan/checks.go
+++ b/build/sync/plan/checks.go
@@ -133,8 +133,7 @@ func (f FileUnalteredChecker) Check(path string, setup Setup) error {
 		} else {
 			return fmt.Errorf("failed to get stat for %q: %v", trgPath, err)
 		}
-	}
-	if srcInfo.IsDir() {
+	} else if srcInfo.IsDir() {
 		return fmt.Errorf("%q is a directory in source repository", path)
 	}
 

--- a/build/sync/plan/checks_test.go
+++ b/build/sync/plan/checks_test.go
@@ -7,8 +7,10 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+	"time"
 
 	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/mattermost/mattermost-plugin-starter-template/build/sync/plan"
@@ -91,7 +93,7 @@ func tempGitRepo(assert *assert.Assertions) (string, *git.Repository, func()) {
 	err = ioutil.WriteFile(filepath.Join(wd, "test"),
 		[]byte("lorem ipsum"), 0644)
 	assert.Nil(err)
-	sig := git.Signature{
+	sig := &object.Signature{
 		Name:  "test",
 		Email: "test@example.com",
 		When:  time.Now(),

--- a/build/sync/plan/checks_test.go
+++ b/build/sync/plan/checks_test.go
@@ -48,7 +48,13 @@ func TestRepoIsCleanChecker(t *testing.T) {
 func TestPathExistsChecker(t *testing.T) {
 	assert := assert.New(t)
 
-	wd, err := os.Getwd()
+	// Set up a working directory.
+	wd, err := ioutil.TempDir("", "repo")
+	assert.Nil(err)
+	defer os.RemoveAll(wd)
+	err = os.Mkdir(filepath.Join(wd, "t"), 0755)
+	assert.Nil(err)
+	err = ioutil.WriteFile(filepath.Join(wd, "t", "test"), []byte("lorem ipsum"), 0644)
 	assert.Nil(err)
 
 	checker := plan.PathExistsChecker{}
@@ -61,30 +67,55 @@ func TestPathExistsChecker(t *testing.T) {
 	}
 
 	// Check with existing directory.
-	assert.Nil(checker.Check("testdata", ctx))
+	assert.Nil(checker.Check("t", ctx))
 
 	// Check with existing file.
-	assert.Nil(checker.Check("testdata/a", ctx))
+	assert.Nil(checker.Check("t/test", ctx))
 
 	err = checker.Check("nosuchpath", ctx)
 	assert.NotNil(err)
 	assert.True(plan.IsCheckFail(err))
 }
 
+func tempGitRepo(assert *assert.Assertions) (string, *git.Repository, func()) {
+	// Setup repository.
+	wd, err := ioutil.TempDir("", "repo")
+	assert.Nil(err)
+
+	// Initialize a repository.
+	repo, err := git.PlainInit(wd, false)
+	assert.Nil(err)
+	w, err := repo.Worktree()
+	assert.Nil(err)
+	// Create repository files.
+	err = ioutil.WriteFile(filepath.Join(wd, "test"),
+		[]byte("lorem ipsum"), 0644)
+	assert.Nil(err)
+	_, err = w.Commit("initial commit", &git.CommitOptions{})
+	assert.Nil(err)
+	pathA := "a.txt"
+	err = ioutil.WriteFile(filepath.Join(wd, pathA),
+		[]byte("lorem ipsum"), 0644)
+	assert.Nil(err)
+	_, err = w.Add(pathA)
+	assert.Nil(err)
+	_, err = w.Commit("add files", &git.CommitOptions{})
+	assert.Nil(err)
+
+	return wd, repo, func() { os.RemoveAll(wd) }
+
+}
+
 func TestUnalteredCheckerSameFile(t *testing.T) {
 	assert := assert.New(t)
 
-	// Path to the root of the repo.
-	wd, err := filepath.Abs("../../../")
-	assert.Nil(err)
-
-	gitRepo, err := git.PlainOpen(wd)
-	assert.Nil(err)
+	wd, repo, cleanup := tempGitRepo(assert)
+	defer cleanup()
 
 	ctx := plan.Setup{
 		Source: plan.RepoSetup{
 			Path: wd,
-			Git:  gitRepo,
+			Git:  repo,
 		},
 		Target: plan.RepoSetup{
 			Path: wd,
@@ -96,25 +127,21 @@ func TestUnalteredCheckerSameFile(t *testing.T) {
 	checker.Params.TargetRepo = plan.TargetRepo
 
 	// Check with the same file - check should succeed
-	hashPath := "build/sync/plan/testdata/a"
-	err = checker.Check(hashPath, ctx)
+	hashPath := "a.txt"
+	err := checker.Check(hashPath, ctx)
 	assert.Nil(err)
 }
 
 func TestUnalteredCheckerDifferentContents(t *testing.T) {
 	assert := assert.New(t)
 
-	// Path to the root of the repo.
-	wd, err := filepath.Abs("../../../")
-	assert.Nil(err)
-
-	gitRepo, err := git.PlainOpen(wd)
-	assert.Nil(err)
+	wd, repo, cleanup := tempGitRepo(assert)
+	defer cleanup()
 
 	ctx := plan.Setup{
 		Source: plan.RepoSetup{
 			Path: wd,
-			Git:  gitRepo,
+			Git:  repo,
 		},
 		Target: plan.RepoSetup{
 			Path: wd,
@@ -126,25 +153,18 @@ func TestUnalteredCheckerDifferentContents(t *testing.T) {
 	checker.Params.TargetRepo = plan.TargetRepo
 
 	// Create a file with the same suffix path, but different contents.
-	hashPath := "build/sync/plan/testdata/a"
 	tmpDir, err := ioutil.TempDir("", "test")
 	assert.Nil(err)
 	defer os.RemoveAll(tmpDir)
-	fullPath := filepath.Join(tmpDir, "build/sync/plan/testdata")
-	err = os.MkdirAll(fullPath, 0777)
+	err = ioutil.WriteFile(filepath.Join(tmpDir, "a.txt"),
+		[]byte("not lorem ipsum"), 0644)
 	assert.Nil(err)
-	file, err := os.OpenFile(filepath.Join(fullPath, "a"), os.O_CREATE|os.O_WRONLY, 0755)
-	assert.Nil(err)
-	_, err = file.WriteString("this file has different contents")
-	assert.Nil(err)
-	assert.Nil(file.Close())
 
 	// Set the plugin path to the temporary directory.
 	ctx.Target.Path = tmpDir
-
-	err = checker.Check(hashPath, ctx)
+	err = checker.Check("a.txt", ctx)
 	assert.True(plan.IsCheckFail(err))
-	assert.EqualError(err, fmt.Sprintf("file %q has been altered", filepath.Join(tmpDir, hashPath)))
+	assert.EqualError(err, fmt.Sprintf("file %q has been altered", filepath.Join(tmpDir, "a.txt")))
 
 }
 
@@ -153,13 +173,10 @@ func TestUnalteredCheckerDifferentContents(t *testing.T) {
 // the checker should pass.
 func TestUnalteredCheckerNonExistant(t *testing.T) {
 	assert := assert.New(t)
-	hashPath := "build/sync/plan/testdata/a"
+	hashPath := "a.txt"
 
-	// Path to the root of the repo.
-	wd, err := filepath.Abs("../../../")
-	assert.Nil(err)
-	gitRepo, err := git.PlainOpen(wd)
-	assert.Nil(err)
+	wd, repo, cleanup := tempGitRepo(assert)
+	defer cleanup()
 
 	// Temporary repo.
 	tmpDir, err := ioutil.TempDir("", "test")
@@ -172,7 +189,7 @@ func TestUnalteredCheckerNonExistant(t *testing.T) {
 	ctx := plan.Setup{
 		Source: plan.RepoSetup{
 			Path: wd,
-			Git:  gitRepo,
+			Git:  repo,
 		},
 		Target: plan.RepoSetup{
 			Path: tmpDir,

--- a/build/sync/plan/checks_test.go
+++ b/build/sync/plan/checks_test.go
@@ -91,7 +91,12 @@ func tempGitRepo(assert *assert.Assertions) (string, *git.Repository, func()) {
 	err = ioutil.WriteFile(filepath.Join(wd, "test"),
 		[]byte("lorem ipsum"), 0644)
 	assert.Nil(err)
-	_, err = w.Commit("initial commit", &git.CommitOptions{})
+	sig := git.Signature{
+		Name:  "test",
+		Email: "test@example.com",
+		When:  time.Now(),
+	}
+	_, err = w.Commit("initial commit", &git.CommitOptions{Author: sig})
 	assert.Nil(err)
 	pathA := "a.txt"
 	err = ioutil.WriteFile(filepath.Join(wd, pathA),
@@ -99,7 +104,7 @@ func tempGitRepo(assert *assert.Assertions) (string, *git.Repository, func()) {
 	assert.Nil(err)
 	_, err = w.Add(pathA)
 	assert.Nil(err)
-	_, err = w.Commit("add files", &git.CommitOptions{})
+	_, err = w.Commit("add files", &git.CommitOptions{Author: sig})
 	assert.Nil(err)
 
 	return wd, repo, func() { os.RemoveAll(wd) }

--- a/build/sync/plan/git/file_history.go
+++ b/build/sync/plan/git/file_history.go
@@ -22,6 +22,7 @@ var ErrNotFound = fmt.Errorf("not found")
 func FileHistory(path string, repo *git.Repository) ([]string, error) {
 	logOpts := git.LogOptions{
 		FileName: &path,
+		All:      true,
 	}
 	commits, err := repo.Log(&logOpts)
 	if errors.Is(err, plumbing.ErrReferenceNotFound) {
@@ -31,7 +32,6 @@ func FileHistory(path string, repo *git.Repository) ([]string, error) {
 		return nil, fmt.Errorf("failed to get commits for path %q: %v", path, err)
 	}
 	defer commits.Close()
-
 	hashHistory := []string{}
 	cerr := commits.ForEach(func(c *object.Commit) error {
 		root, err := repo.TreeObject(c.TreeHash)

--- a/build/sync/plan/git/file_history_test.go
+++ b/build/sync/plan/git/file_history_test.go
@@ -31,7 +31,12 @@ func TestFileHistory(t *testing.T) {
 	assert.Nil(err)
 	_, err = w.Add("test")
 	assert.Nil(err)
-	_, err = w.Commit("initial commit", &git.CommitOptions{})
+	sig := git.Signature{
+		Name:  "test",
+		Email: "test@example.com",
+		When:  time.Now(),
+	}
+	_, err = w.Commit("initial commit", &git.CommitOptions{Author: sig})
 	assert.Nil(err)
 	pathA := "a.txt"
 	err = ioutil.WriteFile(filepath.Join(dir, pathA), fileContents, 0644)
@@ -43,12 +48,15 @@ func TestFileHistory(t *testing.T) {
 	assert.Nil(err)
 	_, err = w.Add(pathB)
 	assert.Nil(err)
-	_, err = w.Commit("add files", &git.CommitOptions{})
+	_, err = w.Commit("add files", &git.CommitOptions{Author: sig})
 	assert.Nil(err)
 	// Delete one of the files.
 	_, err = w.Remove(pathB)
 	assert.Nil(err)
-	_, err = w.Commit("remove file b.txt", &git.CommitOptions{All: true})
+	_, err = w.Commit("remove file b.txt", &git.CommitOptions{
+		Author: sig,
+		All:    true,
+	})
 	assert.Nil(err)
 
 	repo, err = git.PlainOpen(dir)

--- a/build/sync/plan/git/file_history_test.go
+++ b/build/sync/plan/git/file_history_test.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/stretchr/testify/assert"
 
 	gitutil "github.com/mattermost/mattermost-plugin-starter-template/build/sync/plan/git"
@@ -31,7 +33,7 @@ func TestFileHistory(t *testing.T) {
 	assert.Nil(err)
 	_, err = w.Add("test")
 	assert.Nil(err)
-	sig := git.Signature{
+	sig := &object.Signature{
 		Name:  "test",
 		Email: "test@example.com",
 		When:  time.Now(),

--- a/build/sync/plan/git/file_history_test.go
+++ b/build/sync/plan/git/file_history_test.go
@@ -2,6 +2,7 @@ package git_test
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -18,7 +19,7 @@ func TestFileHistory(t *testing.T) {
 
 	dir, err := ioutil.TempDir("", "repo")
 	assert.Nil(err)
-	//defer os.RemoveAll(dir)
+	defer os.RemoveAll(dir)
 
 	// Initialize a repository.
 	repo, err := git.PlainInit(dir, false)

--- a/build/sync/plan/git/testdata/testfile.txt
+++ b/build/sync/plan/git/testdata/testfile.txt
@@ -1,1 +1,0 @@
-This file is used to test file history tracking.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,10 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattermost/mattermost-server/v5 v5.26.2
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/go-git/go-git/v5 v5.1.0
+	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20200723144633-ed34468996e6
 	github.com/pkg/errors v0.9.1
+	github.com/rogpeppe/gohack v1.0.2 // indirect
 	github.com/stretchr/testify v1.6.1
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattermost/mattermost-server/v5 v5.26.2
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/go-git/go-git/v5 v5.1.0
-	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20200723144633-ed34468996e6
 	github.com/pkg/errors v0.9.1
-	github.com/rogpeppe/gohack v1.0.2 // indirect
 	github.com/stretchr/testify v1.6.1
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -92,7 +92,6 @@ github.com/couchbase/moss v0.1.0/go.mod h1:9MaHIaRuy9pvLPUJxB8sh8OrLfyDczECVL37g
 github.com/couchbase/vellum v1.0.1/go.mod h1:FcwrEivFpNi24R3jLOs3n+fs5RnuQnQqCLBJ1uAg1W4=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
@@ -155,14 +154,6 @@ github.com/go-asn1-ber/asn1-ber v1.5.1 h1:pDbRAunXzIUXfx4CB2QJFv5IuPiuoW+sWvr/Us
 github.com/go-asn1-ber/asn1-ber v1.5.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
-github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
-github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
-github.com/go-git/go-billy/v5 v5.0.0 h1:7NQHvd9FVid8VL4qVUMm8XifBK+2xCoZ2lSk0agRrHM=
-github.com/go-git/go-billy/v5 v5.0.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
-github.com/go-git/go-git-fixtures/v4 v4.0.1 h1:q+IFMfLx200Q3scvt2hN79JsEzy4AmBTp/pqnefH+Bc=
-github.com/go-git/go-git-fixtures/v4 v4.0.1/go.mod h1:m+ICp2rF3jDhFgEZ/8yziagdT1C+ZpZcrJjappBCDSw=
-github.com/go-git/go-git/v5 v5.1.0 h1:HxJn9g/E7eYvKW3Fm7Jt4ee8LXfPOm/H1cdDu8vEssk=
-github.com/go-git/go-git/v5 v5.1.0/go.mod h1:ZKfuPUoY1ZqIG4QG9BDBh3G4gLM5zvPuSJAozQrZuyM=
 github.com/go-gorp/gorp v2.2.0+incompatible/go.mod h1:7IfkAQnO7jfT/9IQ3R9wL1dFhukN6aQxzKTHnkxzA/E=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -279,8 +270,6 @@ github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce/go.mod h1:+NfK9FKe
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428/go.mod h1:uhpZMVGznybq1itEKXj6RYw9I71qK4kH+OGMjRC4KEo=
-github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
-github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
@@ -488,11 +477,8 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
-github.com/rogpeppe/go-internal v1.0.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/gohack v1.0.2 h1:lYiGLFzvZC3RvzeE4GoUV3nTecDxTpVusVsQY4nAXGc=
-github.com/rogpeppe/gohack v1.0.2/go.mod h1:DE8wqaJRPvHU0fden5cSYy7ar2dTbbccPT/eeOYcbcE=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rudderlabs/analytics-go v3.2.1+incompatible/go.mod h1:LF8/ty9kUX4PTY3l5c97K3nZZaX5Hwsvt+NBaRL/f30=
 github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7/go.mod h1:Oz4y6ImuOQZxynhbSXk7btjEfNBtGlj2dcaOvXl2FSM=
@@ -505,8 +491,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3/go.mod h1:9/Rh6yILuLysoQnZ2oNooD2g7aBnvM7r/fNVxRNWfBc=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
-github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=
 github.com/shurcooL/github_flavored_markdown v0.0.0-20181002035957-2122de532470/go.mod h1:2dOwnU2uBioM+SGy2aZoq1f/Sd1l9OkAeAUvjSyvgU0=
@@ -650,7 +634,6 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -740,7 +723,6 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,7 @@ github.com/couchbase/moss v0.1.0/go.mod h1:9MaHIaRuy9pvLPUJxB8sh8OrLfyDczECVL37g
 github.com/couchbase/vellum v1.0.1/go.mod h1:FcwrEivFpNi24R3jLOs3n+fs5RnuQnQqCLBJ1uAg1W4=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cznic/b v0.0.0-20181122101859-a26611c4d92d/go.mod h1:URriBxXwVq5ijiJ12C7iIZqlA69nTlI+LgI6/pwftG8=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
@@ -154,6 +155,14 @@ github.com/go-asn1-ber/asn1-ber v1.5.1 h1:pDbRAunXzIUXfx4CB2QJFv5IuPiuoW+sWvr/Us
 github.com/go-asn1-ber/asn1-ber v1.5.1/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
+github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
+github.com/go-git/gcfg v1.5.0/go.mod h1:5m20vg6GwYabIxaOonVkTdrILxQMpEShl1xiMF4ua+E=
+github.com/go-git/go-billy/v5 v5.0.0 h1:7NQHvd9FVid8VL4qVUMm8XifBK+2xCoZ2lSk0agRrHM=
+github.com/go-git/go-billy/v5 v5.0.0/go.mod h1:pmpqyWchKfYfrkb/UVH4otLvyi/5gJlGI4Hb3ZqZ3W0=
+github.com/go-git/go-git-fixtures/v4 v4.0.1 h1:q+IFMfLx200Q3scvt2hN79JsEzy4AmBTp/pqnefH+Bc=
+github.com/go-git/go-git-fixtures/v4 v4.0.1/go.mod h1:m+ICp2rF3jDhFgEZ/8yziagdT1C+ZpZcrJjappBCDSw=
+github.com/go-git/go-git/v5 v5.1.0 h1:HxJn9g/E7eYvKW3Fm7Jt4ee8LXfPOm/H1cdDu8vEssk=
+github.com/go-git/go-git/v5 v5.1.0/go.mod h1:ZKfuPUoY1ZqIG4QG9BDBh3G4gLM5zvPuSJAozQrZuyM=
 github.com/go-gorp/gorp v2.2.0+incompatible/go.mod h1:7IfkAQnO7jfT/9IQ3R9wL1dFhukN6aQxzKTHnkxzA/E=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -270,6 +279,8 @@ github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce/go.mod h1:+NfK9FKe
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428/go.mod h1:uhpZMVGznybq1itEKXj6RYw9I71qK4kH+OGMjRC4KEo=
+github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
+github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
@@ -477,7 +488,11 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/rogpeppe/go-internal v1.0.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/gohack v1.0.2 h1:lYiGLFzvZC3RvzeE4GoUV3nTecDxTpVusVsQY4nAXGc=
+github.com/rogpeppe/gohack v1.0.2/go.mod h1:DE8wqaJRPvHU0fden5cSYy7ar2dTbbccPT/eeOYcbcE=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rudderlabs/analytics-go v3.2.1+incompatible/go.mod h1:LF8/ty9kUX4PTY3l5c97K3nZZaX5Hwsvt+NBaRL/f30=
 github.com/russellhaering/goxmldsig v0.0.0-20180430223755-7acd5e4a6ef7/go.mod h1:Oz4y6ImuOQZxynhbSXk7btjEfNBtGlj2dcaOvXl2FSM=
@@ -490,6 +505,8 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3/go.mod h1:9/Rh6yILuLysoQnZ2oNooD2g7aBnvM7r/fNVxRNWfBc=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
+github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/component v0.0.0-20170202220835-f88ec8f54cc4/go.mod h1:XhFIlyj5a1fBNx5aJTbKoIq0mNaPvOagO+HjB3EtxrY=
 github.com/shurcooL/events v0.0.0-20181021180414-410e4ca65f48/go.mod h1:5u70Mqkb5O5cxEA8nxTsgrgLehJeAw6Oc4Ab1c/P1HM=
 github.com/shurcooL/github_flavored_markdown v0.0.0-20181002035957-2122de532470/go.mod h1:2dOwnU2uBioM+SGy2aZoq1f/Sd1l9OkAeAUvjSyvgU0=
@@ -633,6 +650,7 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -722,6 +740,7 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
@@ -826,6 +845,7 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/errgo.v2 v2.1.0 h1:0vLT13EuvQ0hNvakwLuFZ/jYrLp5F3kcWHXdRggjCE8=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=


### PR DESCRIPTION
#### Summary
Improve file history related tests in the synchronization tool to not rely on the git history of the starter template repository.

#### Ticket Link
  Fixes #134 

