### PR TITLE
Disable fieldalignment golangci-lint check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,8 @@ linters-settings:
   govet:
     check-shadowing: true
     enable-all: true
+    disable:
+      - fieldalignment
   misspell:
     locale: US
 


### PR DESCRIPTION
#### Summary
Disable the newly added `fieldalignment` check as it proves little value for new devs.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-plugin-starter-template/issues/148