### PR TITLE
golangci: disable fieldalignment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,8 @@ linters-settings:
   govet:
     check-shadowing: true
     enable-all: true
+    disable:
+      - fieldalignment
   misspell:
     locale: US
 


### PR DESCRIPTION
#### Summary
Disable `fieldalignment` for golangci -- this is an over optimization in most every use case and doesn't need to be on by default.

#### Ticket Link
None.