### PR TITLE
Added Enable upload to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ If your Mattermost server is running locally, you can enable [local mode](https:
         ...
         "EnableLocalMode": true,
         "LocalModeSocketLocation": "/var/tmp/mattermost_local.socket"
+    },
+    "PluginSettings" : {
+        ...
+        "EnableUploads" : true
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,14 @@ dist/com.example.my-plugin.tar.gz
 
 ## Development
 
-To avoid having to manually install your plugin, build and deploy your plugin using one of the following options.
+To avoid having to manually install your plugin, build and deploy your plugin using one of the following options. In order for the below options to work, you must first enable plugin uploads via your config.json or API and restart Mattermost.
+
+```json
+    "PluginSettings" : {
+        ...
+        "EnableUploads" : true
+    }
+```
 
 ### Deploying with Local Mode
 
@@ -63,10 +70,6 @@ If your Mattermost server is running locally, you can enable [local mode](https:
         "EnableLocalMode": true,
         "LocalModeSocketLocation": "/var/tmp/mattermost_local.socket"
     },
-    "PluginSettings" : {
-        ...
-        "EnableUploads" : true
-    }
 }
 ```
 


### PR DESCRIPTION

#### Summary
```bash
./build/bin/pluginctl deploy com.coltonshaw.additional-banner dist/com.coltonshaw.additional-banner-1.5.1.tar.gz
2022/01/25 15:43:36 Connecting using local mode over /var/tmp/mattermost_local.socket
2022/01/25 15:43:36 Uploading plugin via API.
Failed: failed to upload plugin bundle: : Plugins and/or plugin uploads have been disabled., 
```

Plugin uploads are not enabled by default

