### PR TITLE
MM-47046 Use version of React DOM provided by web app

### DIFF
--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -81,6 +81,7 @@ module.exports = {
     },
     externals: {
         react: 'React',
+        'react-dom': 'ReactDOM',
         redux: 'Redux',
         'react-redux': 'ReactRedux',
         'prop-types': 'PropTypes',


### PR DESCRIPTION
For some more context, see [here](https://community.mattermost.com/core/pl/1fkkx7pj1jrwffrc6drh3x71eh). The short version though is that we updated the web app to React 17, and there's a chance that plugins will have some issues with it because they're compiled with the React 16 version of ReactDOM. I'm submitting PRs to the 3 products, the demo plugin, and the plugin template to have them use the web app's version of React DOM to fix any immediate issues, but we'll want to properly migrate them to React 17 going forward.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-47046

#### Related Pull Requests
https://github.com/mattermost/mattermost-plugin-playbooks/pull/1489
https://github.com/mattermost/focalboard/pull/3861
https://github.com/mattermost/mattermost-plugin-todo/pull/190
https://github.com/mattermost/mattermost-plugin-demo/pull/153
