### PR TITLE
Update orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  plugin-ci: mattermost/plugin-ci@0.1.6
+  plugin-ci: mattermost/plugin-ci@0.1.12
 
 workflows:
   version: 2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,7 +37,6 @@ linters:
     - unused
     - whitespace
 
-
 issues:
   exclude-rules:
     - path: server/configuration.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,11 +40,6 @@ linters:
 
 issues:
   exclude-rules:
-    - path: server/manifest.go
-      linters:
-        - deadcode
-        - unused
-        - varcheck
     - path: server/configuration.go
       linters:
         - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,8 +7,6 @@ linters-settings:
     simplify: true
   goimports:
     local-prefixes: github.com/mattermost/mattermost-starter-template
-  golint:
-    min-confidence: 0
   govet:
     check-shadowing: true
     enable-all: true
@@ -21,26 +19,24 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - errcheck
     - gocritic
     - gofmt
     - goimports
-    - golint
     - gosec
     - gosimple
     - govet
     - ineffassign
     - misspell
     - nakedret
+    - revive
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
+
 
 issues:
   exclude-rules:

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,7 +20,7 @@ func TestServeHTTP(t *testing.T) {
 	result := w.Result()
 	assert.NotNil(result)
 	defer result.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(result.Body)
+	bodyBytes, err := io.ReadAll(result.Body)
 	assert.Nil(err)
 	bodyString := string(bodyBytes)
 


### PR DESCRIPTION
#### Summary
- Update orb version
- Fix linter errors caused by `golangci-lint` update

#### Ticket Link
https://github.com/mattermost/circleci-orbs/pull/35