### PR TITLE
 Bump up min_server_version to match mattermost-server in go.mod

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -7,7 +7,7 @@
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-starter-template/releases/tag/v0.1.0",
     "icon_path": "assets/starter-template-icon.svg",
     "version": "0.1.0",
-    "min_server_version": "5.37.0",
+    "min_server_version": "6.2.1",
     "server": {
         "executables": {
             "linux-amd64": "server/dist/plugin-linux-amd64",


### PR DESCRIPTION
#### Summary
Bump up min_server_version to match mattermost-server in go.mod


#### Ticket Link
Fixes #172


