### PR TITLE
Avoid running daily workflow jobs on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,6 @@ permissions:
 
 jobs:
   plugin-ci:
+    if: ${{ github.event_name != 'schedule' || github.repository_owner == 'mattermost' }}
     uses: mattermost/actions-workflows/.github/workflows/plugin-ci.yml@main
     secrets: inherit


### PR DESCRIPTION
#### Summary

More context here https://community.mattermost.com/private-core/pl/s4shju1pwbyabgchwd83mq8h1w

There have been some issues coming up with forked repositories reaching usage limits, due to the plugin project CI workflows running every day.

This PR makes it so these jobs only run daily on Mattermost's copy, to avoid running on forks.

I'm wondering if we can instead make this a holistic change for all repos by applying in the shared actions repo https://github.com/mattermost/actions/blob/main/plugin-ci/test/action.yaml, but I'm not sure this is possible.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-52588