### PR TITLE
fix: replace any backticks (`) in manifestStr

### DIFF
--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -160,6 +160,9 @@ func applyManifest(manifest *model.Manifest) error {
 		}
 		manifestStr := string(manifestBytes)
 
+		// replace any backtiks (`) in manifestStr with suitable replacement for multiline literal
+		manifestStr = strings.ReplaceAll(manifestStr, "`", "` + \"`\" + `")
+
 		// write generated code to file by using Go file template.
 		if err := os.WriteFile(
 			"server/manifest.go",


### PR DESCRIPTION
#### Summary
if manifestStr (read from plugin.json) has any '`' characters in it, such as when using markdown formatting in a text value, the generated go code fails to build due to unescaped '`' characters, leading the compiler to believe some input is mismatched.

This change passes the manifestStr through a Replacement filter to replace the ` characters with input which will be properly formatted through the compiler.


#### Ticket Link
n/a

