### PR TITLE
[MM-57855] Add manifest validation step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ endif
 .PHONY: all
 all: check-style test dist
 
+## Ensures the plugin manifest is valid
+.PHONY: manifest-check
+manifest-check:
+	./build/bin/manifest check
+
 ## Propagates plugin manifest information into the server/ and webapp/ folders.
 .PHONY: apply
 apply:
@@ -56,7 +61,7 @@ install-go-tools:
 
 ## Runs eslint and golangci-lint
 .PHONY: check-style
-check-style: apply webapp/node_modules install-go-tools
+check-style: manifest-check apply webapp/node_modules install-go-tools
 	@echo Checking for style guide compliance
 
 ifneq ($(HAS_WEBAPP),)

--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -86,6 +86,11 @@ func main() {
 			panic("failed to write manifest to dist directory: " + err.Error())
 		}
 
+	case "check":
+		if err := manifest.IsValid(); err != nil {
+			panic("failed to check manifest: " + err.Error())
+		}
+
 	default:
 		panic("unrecognized command: " + cmd)
 	}


### PR DESCRIPTION
#### Summary
- Last week we had a bit of trouble where a plugin settings field type was wrong. The plugin was functional, but the manifest validation step in the marketplace `generate` step failed. Moving that validation step up to the plugin side will prevent that from happening again, https://github.com/mattermost/mattermost-plugin-calls/pull/689.
-  Sending this change upstream.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-57855