### PR TITLE
Add emotion/react dependency

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -25,6 +25,7 @@
     "@babel/runtime": "7.16.7",
     "@emotion/babel-preset-css-prop": "11.2.0",
     "@emotion/core": "10.3.1",
+    "@emotion/react": "11.9.0",
     "@mattermost/types": "6.7.0-0",
     "@testing-library/jest-dom": "5.16.1",
     "@types/babel__core": "7.1.18",


### PR DESCRIPTION
#### Summary

Adds `emotion/react` to the webapp dependencies.

When migrating a plugin to the latest template, I found it had a missing dependency on `emotion/react`, referencing this line:
```javascript
export default class UserAttribute extends React.PureComponent {
```

Seems worth adding to the `package.json`. I picked a version of similar age to `emotion/core` and all seemed well.