### PR TITLE
fix: tar bundle error on mac silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ ifneq ($(HAS_WEBAPP),)
 	mkdir -p dist/$(PLUGIN_ID)/webapp
 	cp -r webapp/dist dist/$(PLUGIN_ID)/webapp/
 endif
-	cd dist && tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
+	cd dist && COPYFILE_DISABLE=1 tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
 
 	@echo plugin built at: dist/$(BUNDLE_NAME)
 


### PR DESCRIPTION

#### Summary


tar -cvzf command creates ._ files to store extended attributes. You need to tell tar to remove the metadata by setting COPYFILE_DISABLE

So run COPYFILE_DISABLE=1 tar -cvzf to make tar file to upload as plugin.

#### Ticket Link

https://github.com/mattermost/mattermost/issues/22614

