### PR TITLE
Avoid issues on Darwin bundling the plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,11 @@ ifneq ($(HAS_WEBAPP),)
 	mkdir -p dist/$(PLUGIN_ID)/webapp
 	cp -r webapp/dist dist/$(PLUGIN_ID)/webapp/
 endif
+ifeq ($(shell uname),Darwin)
+	cd dist && tar --disable-copyfile -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
+else
 	cd dist && tar -cvzf $(BUNDLE_NAME) $(PLUGIN_ID)
+endif
 
 	@echo plugin built at: dist/$(BUNDLE_NAME)
 


### PR DESCRIPTION
#### Summary
Effectively work around the following error (example from Playbooks):
```
plugin built at: dist/playbooks-+59740baf.tar.gz
./build/bin/pluginctl deploy playbooks dist/playbooks-+59740baf.tar.gz
2023/01/11 14:23:30 Connecting using local mode over /var/tmp/mattermost_local.socket
2023/01/11 14:23:30 Uploading plugin via API.
Failed: failed to upload plugin bundle: : Unable to find manifest for extracted plugin., open /var/folders/44/tv5rv9_j6r1bl4rj0qxpy1jh0000gn/T/plugintmp3335227689/plugin.json: no such file or directory
```

See also https://github.com/mattermost/mattermost-plugin-playbooks/pull/1745. I'm not sure how this hasn't made it into the starter template before now :(

#### Ticket Link
None
