### PR TITLE
Disable eslint header rule

### DIFF
--- a/webapp/.eslintrc.json
+++ b/webapp/.eslintrc.json
@@ -2,5 +2,8 @@
   "root": true,
   "extends": [
     "plugin:@mattermost/react"
-  ]
+  ],
+  "rules": {
+    "header/header": "off"
+  }
 }


### PR DESCRIPTION
The imported eslint config tells eslint that we should add a mattermost copyright header to every file. For users developing their own plugins, this should be disabled.