### PR TITLE
Make import path specs consistent and fix error when running tests that use jsx/tsx

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -97,7 +97,7 @@
       "^bundle-loader\\?lazy\\!(.*)$": "$1"
     },
     "moduleDirectories": [
-      "",
+      "src",
       "node_modules",
       "non_npm_dependencies"
     ],

--- a/webapp/src/index.tsx
+++ b/webapp/src/index.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import manifest from 'manifest';
 import type {Store, Action} from 'redux';
 
 import type {GlobalState} from '@mattermost/types/store';
 
-import manifest from '@/manifest';
-import type {PluginRegistry} from '@/types/mattermost-webapp';
+import type {PluginRegistry} from 'types/mattermost-webapp';
 
 export default class Plugin {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function

--- a/webapp/src/manifest.test.tsx
+++ b/webapp/src/manifest.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import manifest from './manifest';
+import manifest from 'manifest';
 
 test('Plugin manifest, id and version are defined', () => {
     expect(manifest).toBeDefined();

--- a/webapp/src/react_fragment.test.tsx
+++ b/webapp/src/react_fragment.test.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+function generateSomething() {
+    return <div>{'something'}</div>;
+}
+
+test('Can test React fragments', () => {
+    expect(React.version).toEqual('17.0.2');
+    expect(generateSomething()).toBeDefined();
+});

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -1,10 +1,7 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "baseUrl": "./",
-    "paths": {
-      "@/*": ["src/*"],
-    },
+    "baseUrl": "./src",
     "lib": [
       "dom",
       "dom.iterable",

--- a/webapp/webpack.config.js
+++ b/webapp/webpack.config.js
@@ -34,13 +34,9 @@ const config = {
         './src/index.tsx',
     ],
     resolve: {
-        alias: {
-            '@': path.resolve(__dirname, 'src'),
-        },
         modules: [
             'src',
             'node_modules',
-            path.resolve(__dirname),
         ],
         extensions: ['*', '.js', '.jsx', '.ts', '.tsx'],
     },


### PR DESCRIPTION
When jest tests import a `jsx`/`tsx` module, they fail with this obscure error:
```
 FAIL  src/react_fragment.test.tsx
  ● Test suite failed to run

    TypeError: React.createContext is not a function

      at Object.<anonymous> (node_modules/@emotion/react/dist/emotion-element-e89f38a3.cjs.dev.js:41:48)
      at Object.<anonymous> (node_modules/@emotion/react/dist/emotion-react.cjs.dev.js:7:22)

```

The explanation is:
* The use of React fragments causes `emotion` to be loaded
* `emotion` also imports React with `require('react')`
* This causes an ambiguity for the jest loader. The `moduleDirectories` includes both `"node_modules"` and `""`, leading to ambiguity between the actual React module and `emotion/react`. The result of the import ends up being `undefined` which later leads to the error shown.

A similar description of this issue in another project can be seen [here](https://github.com/next-page-tester/next-page-tester/issues/202#issuecomment-813092834).

This is resolved by removing `""` from `moduleDirectories` which seems to be a general recommendation anyway. I note that `mattermost-plugin-demo` does not have this configuration.

The only thing that is lost is the ability to `import ... from 'mymodule'` from a test file, but this can just be replaced by `import ... from './mymodule'`.

I added a test that reproduces the error. (I also confirmed the behaviour is the same whether or not we remove `emotion/core`, as I did in another PR). The test works after the jest config change.