### PR TITLE
Add all types for registry - change `options` argument for `registerAdminConsoleCustomSetting` to optional

### DIFF
--- a/webapp/src/types/mattermost-webapp/index.d.ts
+++ b/webapp/src/types/mattermost-webapp/index.d.ts
@@ -794,11 +794,11 @@ export interface PluginRegistry {
         ...args: [
             key: string,
             component: ReactResolvable,
-            options: { showTitle?: boolean }
+            options?: { showTitle?: boolean }
         ] | [{
             key: string;
             component: ReactResolvable;
-            options: { showTitle?: boolean };
+            options?: { showTitle?: boolean };
         }]
     ): void;
 


### PR DESCRIPTION
Small fix for this PR: https://github.com/mattermost/mattermost-plugin-starter-template/pull/222