### PR TITLE
docs: update readme for clarity on go module path configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Edit the following files:
 module github.com/example/my-plugin
 ```
 
-3. `.golangci.yml` with your Go module path:
+3. Replace all occurrences of `github.com/mattermost/mattermost-plugin-starter-template` in the codebase with your Go module path.
+
+4. `.golangci.yml` with your Go module path:
 ```yml
 linters-settings:
   # [...]
@@ -64,7 +66,7 @@ To avoid having to manually install your plugin, build and deploy your plugin us
     }
 ```
 
-### Development guidance 
+### Development guidance
 
 1. Fewer packages is better: default to the main package unless there's good reason for a new package.
 
@@ -76,7 +78,7 @@ To avoid having to manually install your plugin, build and deploy your plugin us
 
 ### Modifying the server boilerplate
 
-The server code comes with some boilerplate for creating an api, using slash commands, accessing the kvstore and using the cluster package for jobs. 
+The server code comes with some boilerplate for creating an api, using slash commands, accessing the kvstore and using the cluster package for jobs.
 
 #### Api
 


### PR DESCRIPTION
#### Summary

This pull request updates the setup instructions in the `README.md` file to clarify how to replace the default module path when creating a new plugin from the template.

Also using this PR to check problems with the CI that is currently undergoing some issues.

#### Ticket Link

N/A

Closes #224 

