### PR TITLE
fix: miscellaneous bugs and syntax errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,14 +11,14 @@ trim_trailing_whitespace = true
 [*.go]
 indent_style = tab
 
-[*.{js, jsx, ts, tsx, json, html}]
+[*.{js,jsx,ts,tsx,json,html}]
 indent_style = space
 indent_size = 4
 
 [webapp/package.json]
 indent_size = 2
 
-[{Makefile, *.mk}]
+[{Makefile,*.mk}]
 indent_style = tab
 
 [*.md]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,4 +59,4 @@ formatters:
           replacement: any
     goimports:
       local-prefixes:
-        - github.com/mattermost/mattermost-starter-template
+        - github.com/mattermost/mattermost-plugin-starter-template

--- a/build/manifest/main.go
+++ b/build/manifest/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -139,7 +140,11 @@ func findManifest() (*model.Manifest, error) {
 
 	// If no release notes specified, generate one from the latest tag, if present.
 	if manifest.ReleaseNotesURL == "" && BuildTagLatest != "" {
-		manifest.ReleaseNotesURL = manifest.HomepageURL + "releases/tag/" + BuildTagLatest
+		releaseNotesURL, err := url.JoinPath(manifest.HomepageURL, "releases", "tag", BuildTagLatest)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to build release notes URL")
+		}
+		manifest.ReleaseNotesURL = releaseNotesURL
 	}
 
 	return &manifest, nil

--- a/build/pluginctl/logs_test.go
+++ b/build/pluginctl/logs_test.go
@@ -31,14 +31,14 @@ func TestCheckOldestEntry(t *testing.T) {
 		"no new entries, one old entry": {
 			logs:           []string{"old"},
 			oldest:         "old",
-			expectedLogs:   []string{},
+			expectedLogs:   nil,
 			expectedOldest: "old",
 			expectedAllNew: false,
 		},
-		"no new entries, multipile old entries": {
+		"no new entries, multiple old entries": {
 			logs:           []string{"old1", "old2", "old3"},
 			oldest:         "old3",
-			expectedLogs:   []string{},
+			expectedLogs:   nil,
 			expectedOldest: "old3",
 			expectedAllNew: false,
 		},
@@ -49,7 +49,7 @@ func TestCheckOldestEntry(t *testing.T) {
 			expectedOldest: "new",
 			expectedAllNew: true,
 		},
-		"multipile new entries, no old entry": {
+		"multiple new entries, no old entry": {
 			logs:           []string{"new1", "new2", "new3"},
 			oldest:         "old",
 			expectedLogs:   []string{"new1", "new2", "new3"},
@@ -63,14 +63,14 @@ func TestCheckOldestEntry(t *testing.T) {
 			expectedOldest: "new",
 			expectedAllNew: false,
 		},
-		"one new entry, multipile old entries": {
+		"one new entry, multiple old entries": {
 			logs:           []string{"old1", "old2", "old3", "new"},
 			oldest:         "old3",
 			expectedLogs:   []string{"new"},
 			expectedOldest: "new",
 			expectedAllNew: false,
 		},
-		"multipile new entries, ultipile old entries": {
+		"multiple new entries, multiple old entries": {
 			logs:           []string{"old1", "old2", "old3", "new1", "new2", "new3"},
 			oldest:         "old3",
 			expectedLogs:   []string{"new1", "new2", "new3"},

--- a/server/api.go
+++ b/server/api.go
@@ -7,9 +7,8 @@ import (
 	"github.com/mattermost/mattermost/server/public/plugin"
 )
 
-// ServeHTTP demonstrates a plugin that handles HTTP requests by greeting the world.
-// The root URL is currently <siteUrl>/plugins/com.mattermost.plugin-starter-template/api/v1/. Replace com.mattermost.plugin-starter-template with the plugin ID.
-func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
+// initRouter initializes the HTTP router for the plugin.
+func (p *Plugin) initRouter() *mux.Router {
 	router := mux.NewRouter()
 
 	// Middleware to require that the user is logged in
@@ -19,7 +18,13 @@ func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Req
 
 	apiRouter.HandleFunc("/hello", p.HelloWorld).Methods(http.MethodGet)
 
-	router.ServeHTTP(w, r)
+	return router
+}
+
+// ServeHTTP demonstrates a plugin that handles HTTP requests by greeting the world.
+// The root URL is currently <siteUrl>/plugins/com.mattermost.plugin-starter-template/api/v1/. Replace com.mattermost.plugin-starter-template with the plugin ID.
+func (p *Plugin) ServeHTTP(c *plugin.Context, w http.ResponseWriter, r *http.Request) {
+	p.router.ServeHTTP(w, r)
 }
 
 func (p *Plugin) MattermostAuthorizationRequired(next http.Handler) http.Handler {

--- a/server/command/command.go
+++ b/server/command/command.go
@@ -38,7 +38,14 @@ func NewCommandHandler(client *pluginapi.Client) Command {
 
 // ExecuteCommand hook calls this method to execute the commands that were registered in the NewCommandHandler function.
 func (c *Handler) Handle(args *model.CommandArgs) (*model.CommandResponse, error) {
-	trigger := strings.TrimPrefix(strings.Fields(args.Command)[0], "/")
+	fields := strings.Fields(args.Command)
+	if len(fields) == 0 {
+		return &model.CommandResponse{
+			ResponseType: model.CommandResponseTypeEphemeral,
+			Text:         "Empty command",
+		}, nil
+	}
+	trigger := strings.TrimPrefix(fields[0], "/")
 	switch trigger {
 	case helloCommandTrigger:
 		return c.executeHelloCommand(args), nil

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -5,13 +5,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattermost/mattermost-plugin-starter-template/server/command"
-	"github.com/mattermost/mattermost-plugin-starter-template/server/store/kvstore"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
 	"github.com/mattermost/mattermost/server/public/pluginapi/cluster"
 	"github.com/pkg/errors"
+
+	"github.com/mattermost/mattermost-plugin-starter-template/server/command"
+	"github.com/mattermost/mattermost-plugin-starter-template/server/store/kvstore"
 )
 
 // Plugin implements the interface expected by the Mattermost server to communicate between the server and plugin processes.

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/mattermost/mattermost/server/public/pluginapi"
@@ -28,6 +29,9 @@ type Plugin struct {
 	// commandClient is the client used to register and execute slash commands.
 	commandClient command.Command
 
+	// router is the HTTP router for handling API requests.
+	router *mux.Router
+
 	backgroundJob *cluster.Job
 
 	// configurationLock synchronizes access to the configuration.
@@ -45,6 +49,8 @@ func (p *Plugin) OnActivate() error {
 	p.kvstore = kvstore.NewKVStore(p.client)
 
 	p.commandClient = command.NewCommandHandler(p.client)
+
+	p.router = p.initRouter()
 
 	job, err := cluster.Schedule(
 		p.API,

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -12,6 +12,7 @@ import (
 func TestServeHTTP(t *testing.T) {
 	assert := assert.New(t)
 	plugin := Plugin{}
+	plugin.router = plugin.initRouter()
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/hello", nil)
 	r.Header.Set("Mattermost-User-ID", "test-user-id")

--- a/webapp/src/types/mattermost-webapp/index.d.ts
+++ b/webapp/src/types/mattermost-webapp/index.d.ts
@@ -32,7 +32,7 @@ export type PluginComponent = {
     iconUrl?: string;
     mobileIcon?: React.ReactElement;
     filter?: (id: string) => boolean;
-    action?: (...args: unknown) => void;
+    action?: (...args: unknown[]) => void;
     shouldRender?: (state: GlobalState) => boolean;
     hook?: (post: Post, message?: string) => string;
 };


### PR DESCRIPTION
## Summary
- Fix missing slash in `release_notes_url` by using `url.JoinPath` for proper URL construction
- Fix TypeScript type error: `...args: unknown` → `...args: unknown[]` (spread operator requires array type)
- Fix incorrect `local-prefixes` in `.golangci.yml` (was missing `plugin-` prefix)
- Fix `.editorconfig` glob patterns that had spaces inside curly braces
- Reorder imports in `server/plugin.go` per updated linting config
- Add empty command check in `Handle()` to prevent potential panic
- Move router initialization to `OnActivate()` for efficiency (avoid recreating router per request)
- Fix test expectations to match actual nil return values
- Fix typos in test case names

🤖 Generated with [Claude Code](https://claude.com/claude-code)