### PR TITLE
chore: update to Go 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,4 @@ jobs:
     uses: mattermost/actions-workflows/.github/workflows/plugin-ci.yml@main
     secrets: inherit
     with:
-      golang-version: "1.24"
+      golang-version: "1.25"

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ apply:
 ## Install go tools
 install-go-tools:
 	@echo Installing go tools
-	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0
+	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0
 	$(GO) install gotest.tools/gotestsum@v1.13.0
 
 ## Runs eslint and golangci-lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/mattermost-plugin-starter-template
 
-go 1.24.11
+go 1.25
 
 require (
 	github.com/gorilla/mux v1.8.1


### PR DESCRIPTION
## Summary

go1.26 is out now, so we are good to update to go1.25. 

- Update Go version from 1.24 to 1.25 in `go.mod` and CI workflow


🤖 Generated with [Claude Code](https://claude.com/claude-code)