### PR TITLE
feat: remove golang-version parameter from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,3 @@ jobs:
   plugin-ci:
     uses: mattermost/actions-workflows/.github/workflows/plugin-ci.yml@main
     secrets: inherit
-    with:
-      golang-version: "1.24"


### PR DESCRIPTION
#### Summary
Removed the `golang-version` parameter from CI, following: https://github.com/mattermost/actions-workflows/pull/82

