### PR TITLE
chore: remove server/dist folder before creating the server binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,7 @@ ifneq ($(HAS_SERVER),)
 ifneq ($(MM_DEBUG),)
 	$(info DEBUG mode is on; to disable, unset MM_DEBUG)
 endif
+	rm -rf server/dist;
 	mkdir -p server/dist;
 ifneq ($(MM_SERVICESETTINGS_ENABLEDEVELOPER),)
 	@echo Building plugin only for $(DEFAULT_GOOS)-$(DEFAULT_GOARCH) because MM_SERVICESETTINGS_ENABLEDEVELOPER is enabled


### PR DESCRIPTION
This simple change just removes the `server/dist` folder with all the binaries inside before creating the folder again, mainly because we don't do any cleanup meaning if you created your dist files at any time and then start working with `MM_SERVICESETTINGS_ENABLEDEVELOPER` to create the dist file for your distribution only the tarball will still contains binaries for all other platforms/arch combinations because those were never deleted.