### PR TITLE
Exclude webapp from golangci lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,8 @@ linters:
     unqueryvet:
       check-sql-builders: true
   exclusions:
+    paths:
+      - webapp
     rules:
       - path: server/configuration.go
         linters:


### PR DESCRIPTION
There can be golang code in the `webapp/` directory, for example within `npm` packages. To reproduce an error, delete `webapp/package-lock.json` and then `make check-style`. This results in the error:
```
Running golangci-lint
/opt/homebrew/bin/go vet ./...
./mattermost-plugin-starter-template-grubbins.git/bin/golangci-lint run ./...
webapp/node_modules/flatted/golang/pkg/flatted/flatted.go:84:6: slicescontains: Loop can be simplified using slices.Contains (modernize)
					for _, w := range whitelist {
					^
1 issues:
```

We should exclude the whole `webapp` directory from the linter.