### PR TITLE
Document logs and logs-watch commands in pluginctl help text

### DIFF
--- a/build/pluginctl/main.go
+++ b/build/pluginctl/main.go
@@ -21,6 +21,8 @@ Usage:
     pluginctl disable <plugin id>
     pluginctl enable <plugin id>
     pluginctl reset <plugin id>
+    pluginctl logs <plugin id>
+    pluginctl logs-watch <plugin id>
 `
 
 func main() {


### PR DESCRIPTION
## Summary
- `pluginctl`'s help text listed `deploy`, `disable`, `enable`, and `reset`, but was missing `logs` and `logs-watch`, both of which are already implemented in the command switch.

## Test plan
- [x] Inspected `build/pluginctl/main.go` to confirm `logs`/`logs-watch` are handled and now documented